### PR TITLE
完了トグルボタンのSPA化(axios導入)とボタン類のclass調整

### DIFF
--- a/src/app/Http/Controllers/Api/TodoController.php
+++ b/src/app/Http/Controllers/Api/TodoController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Todo;
+
+class TodoController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
+
+    public function toggleCompletion(Request $request, Todo $todo)
+    {
+        $todo->completed = $request->completed;
+        $todo->save();
+
+        return response()->json($todo);
+    }
+}

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/src/config/auth.php
+++ b/src/config/auth.php
@@ -40,6 +40,12 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'api' => [
+            'driver' => 'token',
+            'provider' => 'users',
+            'hash' => false,
+        ],
     ],
 
     /*

--- a/src/cspell.json
+++ b/src/cspell.json
@@ -5,6 +5,7 @@
         "uncompromised",
         "doesnt",
         "Tightenco",
-        "mimetypes"
+        "mimetypes",
+        "axios"
     ]
 }

--- a/src/resources/js/Pages/Todos/Show.vue
+++ b/src/resources/js/Pages/Todos/Show.vue
@@ -2,7 +2,7 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head, Link } from '@inertiajs/inertia-vue3';
 import { Inertia } from '@inertiajs/inertia';
-
+import PrimaryButton from '@/Components/PrimaryButton.vue';
 
 defineProps({
     todo: Object,
@@ -88,10 +88,10 @@ const deleteTodo = id => {
                                     </div>
                                     </div>
                                     <div class="p-2 w-full">
-                                        <Link as="button" :href="route('todos.edit', { todo: todo.id })" class="flex mx-auto text-white bg-blue-500 border-0 py-2 px-8 focus:outline-none hover:bg-blue-600 rounded text-lg">編集</Link>
+                                        <Link as="button" :href="route('todos.edit', { todo: todo.id })" class="flex mx-auto text-white bg-blue-400 border-0 py-2 px-8 focus:outline-none hover:bg-blue-500 rounded text-lg">編集</Link>
                                     </div>
                                     <div class="p-2 mt-20 w-full">
-                                    <button @click="deleteTodo(todo.id)" class="flex mx-auto text-white bg-red-500 border-0 py-2 px-8 focus:outline-none hover:bg-red-600 rounded text-lg">削除</button>
+                                    <button @click="deleteTodo(todo.id)" class="flex mx-auto text-white bg-red-400 border-0 py-2 px-8 focus:outline-none hover:bg-red-500 rounded text-lg">削除</button>
                                     </div>
                                 </div>
                                 </div>

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\TodoController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,4 +17,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::put('/todos/{todo}/toggle', [TodoController::class, 'toggleCompletion']);
 });


### PR DESCRIPTION
# 概要
- 完了・未完了の切り替えボタンの動作の際、inertia.jsによる画面遷移が起こっていた為、SPA化による部分リロードへの変更の為の修正を実施
- 完了・未完了ボタンのclassty調整の為、ボタンタグからボタンコンポーネントへと変更
# 追加/変更点
- Index.vueのtoggleConpletionイベントの通信メソッドをInertia.postからaxios.putへ修正
- Index.vueのv-for内、todo.completedのbuttonタグをPrimaryButton.vueに変更

# 確認方法/確認項目
- タスク一覧画面にて、完了・未完了トグルボタンをクリックした際、画面全体のリロードが起こっていたが、修正後は、ボタンのみの部分リロードで表示が切り替わり、DBへの完了・未完了の状態の保存(UIで切り替えつつphpmyadminにて確認済み)も完了する仕様へと変更